### PR TITLE
Fix includes for RedLib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v0.3.0 – Appearance & Animation Sync
+- Added initial packets for player appearance data and locomotion state
+- Server now stores appearance JSON for spawned entities
+- Clients transmit their current appearance when joining the world
+- Default server port adjusted to 7777

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,47 @@
+# ================================================
+# Full Build Script for Cyberverse (Windows + PowerShell)
+# Save this file as build.ps1 and run it from the project root
+# ================================================
+
+# === CONFIG ===
+$repoRoot = "$PSScriptRoot"
+$vsBuildConfig = "Release"
+$dotnetConfig = "Release"
+$dotnetFramework = "net8.0"
+
+# === Step 1: Build Native Server (C++) ===
+Write-Host ">> Building native server..."
+$nativeBuildDir = "$repoRoot\server\Native\build"
+if (-Not (Test-Path $nativeBuildDir)) {
+    New-Item -ItemType Directory -Path $nativeBuildDir | Out-Null
+}
+Push-Location $nativeBuildDir
+cmake ..
+Pop-Location
+
+# Build native C++ project using MSBuild
+$nativeSln = "$nativeBuildDir\Cyberverse.Server.Native.sln"
+Write-Host ">> Compiling C++ solution..."
+& "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" $nativeSln /p:Configuration=$vsBuildConfig
+
+# === Step 2: Build Managed Server (C#/.NET) ===
+Write-Host ">> Building managed C# server..."
+Push-Location "$repoRoot\server\Managed"
+dotnet restore
+dotnet build -c $dotnetConfig
+Pop-Location
+
+# === Step 3: Build Client Plugin (RED4ext) ===
+Write-Host ">> Building RED4ext client plugin..."
+$clientRed4extDir = "$repoRoot\client\red4ext"
+$clientBuildDir = "$clientRed4extDir\build"
+if (-Not (Test-Path $clientBuildDir)) {
+    New-Item -ItemType Directory -Path $clientBuildDir | Out-Null
+}
+Push-Location $clientBuildDir
+cmake ..
+Pop-Location
+
+$clientSln = "$clientBuildDir\Cyberverse.RED4ext.sln"
+Write-Host ">> Compiling RED4ext client plugin..."
+& "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" $clientSln /p:Configuration=$vsBuildConfig

--- a/client/red4ext/CMakeLists.txt
+++ b/client/red4ext/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 # Change the project name here!
-project(Cyberverse.Red4Ext LANGUAGES CXX)
+project(Cyberverse.Red4Ext LANGUAGES C CXX)
 
 # Set this option to ON to be able to use folders / filters in your project when using Visual Studio.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -13,7 +13,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 # Add RED4ext.SDK as a dependency.
 
 # Uncomment the following line if you want to use the header-only version of RED4ext.SDK.
-#option(RED4EXT_HEADER_ONLY "" ON)
+option(RED4EXT_HEADER_ONLY "" ON)
 
 add_subdirectory(deps/red4ext.sdk)
 set_target_properties(RED4ext.SDK PROPERTIES FOLDER "Dependencies")
@@ -29,7 +29,10 @@ add_library(zpp_bits INTERFACE)
 target_include_directories(zpp_bits INTERFACE "deps/zpp_bits")
 
 # Include Valve's GameNetworkingSockets
-find_package(GameNetworkingSockets CONFIG REQUIRED)
+find_package(GameNetworkingSockets CONFIG QUIET)
+if(NOT GameNetworkingSockets_FOUND)
+    add_subdirectory(deps/GameNetworkingSockets)
+endif()
 
 # Include red lib
 add_compile_definitions(NOMINMAX)

--- a/client/red4ext/src/AppearanceUtils.cpp
+++ b/client/red4ext/src/AppearanceUtils.cpp
@@ -1,0 +1,15 @@
+#include "AppearanceUtils.h"
+#include "RED4ext/Scripting/Functions.hpp"
+#include <RedLib.hpp>
+#include <Red/GameObject.hpp>
+#include <string>
+
+namespace Cyberverse::AppearanceUtils {
+std::string GetPlayerAppearanceJson(const Red::Handle<Red::GameObject>& player)
+{
+    // Placeholder implementation: only capture appearance name
+    RED4ext::CName appName;
+    Red::CallVirtual(player, "GetCurrentAppearanceName", appName);
+    return std::string(appName.ToString());
+}
+}

--- a/client/red4ext/src/AppearanceUtils.h
+++ b/client/red4ext/src/AppearanceUtils.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <RED4ext/RED4ext.hpp>
+#include <RedLib.hpp>
+#include <Red/GameObject.hpp>
+#include <string>
+
+namespace Cyberverse::AppearanceUtils {
+std::string GetPlayerAppearanceJson(const Red::Handle<Red::GameObject>& player);
+}

--- a/client/red4ext/src/CMakeLists.txt
+++ b/client/red4ext/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set(PROJECT_HEADER_FILES
   Main.h
   NetworkGameSystem.h
   Utils.h
+  AppearanceUtils.h
   PlayerActionTracker.h
         PlayerSync/InterpolationData.h
         CommandLine.h
@@ -13,6 +14,7 @@ set(PROJECT_SRC_FILES
   Main.cpp
   NetworkGameSystem.cpp
   PlayerActionTracker.cpp
+  AppearanceUtils.cpp
 )
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${PROJECT_HEADER_FILES} ${PROJECT_SRC_FILES})

--- a/client/red4ext/src/NetworkGameSystem.cpp
+++ b/client/red4ext/src/NetworkGameSystem.cpp
@@ -174,11 +174,16 @@ bool NetworkGameSystem::EnqueueMessage(uint8_t channel_id, T content)
         return false;
     }
 
-    // TODO: derive the send flags from the channel id, i.e. lookup registered channels.
     assert(data.size() < std::numeric_limits<uint32_t>::max());
 
+    ESteamNetworkingSendFlags flags = k_nSteamNetworkingSend_Reliable;
+    if (channel_id == 1)
+    {
+        flags = k_nSteamNetworkingSend_Unreliable;
+    }
+
     const auto result = m_pInterface->SendMessageToConnection(
-        m_hConnection, data.data(), static_cast<uint32_t>(data.size()), k_nSteamNetworkingSend_Reliable, nullptr);
+        m_hConnection, data.data(), static_cast<uint32_t>(data.size()), flags, nullptr);
 
     if (result == k_EResultOK)
     {

--- a/client/red4ext/src/NetworkGameSystem.h
+++ b/client/red4ext/src/NetworkGameSystem.h
@@ -15,11 +15,14 @@
 
 #include <RedLib.hpp>
 #include <clientbound/WorldPacketsClientBound.h>
+#include <clientbound/AppearancePacketsClientBound.h>
 #include <map>
 #include <steam/isteamnetworkingsockets.h>
 #include <steam/steamnetworkingtypes.h>
 
 #include <serverbound/WorldPacketsServerBound.h>
+#include <serverbound/AppearancePacketsServerBound.h>
+#include "AppearanceUtils.h"
 
 class NetworkGameSystem : public Red::IGameSystem
 {
@@ -34,6 +37,7 @@ private:
     std::map<RED4ext::ent::EntityID, InterpolationData> m_interpolationData;
     std::map<RED4ext::ent::EntityID, RED4ext::Handle<RED4ext::AICommand>> m_LastTeleportCommand;
     float m_TimeSinceLastPlayerPositionSync;
+    uint64_t m_networkTickCounter = 0;
 
 private:
     void OnRegisterUpdates(RED4ext::UpdateRegistrar* aRegistrar) override;
@@ -64,6 +68,12 @@ public:
 
     template<typename T>
     bool EnqueueMessage(uint8_t channel_id, T frame);
+
+    uint64_t NextNetworkTick() { return m_networkTickCounter++; }
+
+    std::optional<uint64_t> GetNetworkedEntityId(const RED4ext::ent::EntityID& entityId) const;
+
+    void TrackLocomotion(float deltaTime);
 
     /// Called from the plugin load and unload events
     static bool Load();

--- a/client/red4ext/src/PlayerActionTracker.cpp
+++ b/client/red4ext/src/PlayerActionTracker.cpp
@@ -50,7 +50,15 @@ void PlayerActionTracker::OnShoot(RED4ext::Handle<RED4ext::gameprojectileShootEv
     PlayerShoot player_shoot = {};
     player_shoot.charge = event->params.charge;
     player_shoot.startPoint = Vector3 { event->startPoint.X, event->startPoint.Y, event->startPoint.Z };
-    player_shoot.itemIdWeapon = // TODO: FILL
+    if (!event->weapon.Expired())
+    {
+        auto weapon = event->weapon.Lock();
+        player_shoot.itemIdWeapon = Cyberverse::Utils::GameObject_GetRecordID(weapon).value;
+    }
+    else
+    {
+        player_shoot.itemIdWeapon = 0;
+    }
     Red::GetGameSystem<NetworkGameSystem>()->EnqueueMessage(0, player_shoot);
 }
 

--- a/client/red4ext/src/PlayerActionTracker.h
+++ b/client/red4ext/src/PlayerActionTracker.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <RED4ext/RED4ext.hpp>
-#include "RedLib.hpp"
+#include <RedLib.hpp>
+#include <Red/GameObject.hpp>
 
 #include "RED4ext/CName.hpp"
 #include "RED4ext/Scripting/Natives/Generated/game/Object.hpp"
@@ -17,7 +18,7 @@ class PlayerActionTracker final : public Red::IScriptable
 public:
     void RecordPlayerAction(RED4ext::CName actionName, RED4ext::gameinputActionType actionType, float value);
     void OnShoot(RED4ext::Handle<RED4ext::gameprojectileShootEvent> event);
-    void OnHit(RED4ext::Handle<RED4ext::GameObject> gameObject, RED4ext::Handle<RED4ext::gameHitEvent> event);
+    void OnHit(Red::Handle<Red::GameObject> gameObject, RED4ext::Handle<RED4ext::gameHitEvent> event);
     void OnMounting(RED4ext::Handle<RED4ext::game::mounting::MountingEvent> event);
     void OnUnmounting(RED4ext::Handle<RED4ext::game::mounting::UnmountingEvent> event);
     void OnItemEquipped(RED4ext::TweakDBID slot, RED4ext::ItemID item, bool isWeapon);

--- a/client/red4ext/src/Utils.h
+++ b/client/red4ext/src/Utils.h
@@ -7,11 +7,12 @@
 #include "RED4ext/Scripting/Natives/Generated/ent/EntityID.hpp"
 #include "RED4ext/Scripting/Natives/Generated/game/Object.hpp"
 #include "RED4ext/Scripting/Natives/Generated/vehicle/BaseObject.hpp"
-#include "RedLib.hpp"
+#include <RedLib.hpp>
+#include <Red/GameObject.hpp>
 
 namespace Cyberverse::Utils
 {
-    inline RED4ext::Handle<RED4ext::GameObject> GetPlayer()
+    inline Red::Handle<Red::GameObject> GetPlayer()
     {
         const auto system = Red::GetGameSystem<Red::PlayerSystem>();
         Red::Handle<Red::GameObject> player;
@@ -103,6 +104,13 @@ namespace Cyberverse::Utils
     {
         RED4ext::TweakDBID dbId = {};
         Red::CallVirtual(vehicle, "GetRecordID", dbId);
+        return dbId;
+    }
+
+    inline RED4ext::TweakDBID GameObject_GetRecordID(const Red::Handle<Red::GameObject>& object)
+    {
+        RED4ext::TweakDBID dbId = {};
+        Red::CallVirtual(object, "GetRecordID", dbId);
         return dbId;
     }
 }

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -30,6 +30,6 @@ COPY --from=sdk /app .
 # linker flags to set RPATH to "." (who cares about /workspace/build), but that probably needs OS specific defines to only run on linux
 ENV LD_LIBRARY_PATH .
 USER $APP_UID
-# TODO: Use a non-cringe port.
-EXPOSE 1337
+# Use a more conventional port
+EXPOSE 7777
 ENTRYPOINT ["./Cyberverse.Server"]

--- a/server/Managed/NativeLayer/Protocol/Clientbound/ApplyAppearance.cs
+++ b/server/Managed/NativeLayer/Protocol/Clientbound/ApplyAppearance.cs
@@ -1,0 +1,15 @@
+using System.Runtime.InteropServices;
+using Cyberverse.Server.NativeLayer.Protocol.Common;
+
+namespace Cyberverse.Server.NativeLayer.Protocol.Clientbound;
+
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+public struct ApplyAppearance : IClientBoundPacket
+{
+    public ulong networkedEntityId;
+    public uint dataLength;
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 512)]
+    public byte[] data;
+
+    public EMessageTypeClientbound GetMessageType() => EMessageTypeClientbound.ApplyAppearance;
+}

--- a/server/Managed/NativeLayer/Protocol/Clientbound/EMessageTypeClientbound.cs
+++ b/server/Managed/NativeLayer/Protocol/Clientbound/EMessageTypeClientbound.cs
@@ -7,4 +7,6 @@ public enum EMessageTypeClientbound: ushort
     TeleportEntity = 2,
     DestroyEntity = 3,
     EquipItemEntity = 4,
+    ApplyAppearance = 5,
+    UpdateLocomotion = 6,
 }

--- a/server/Managed/NativeLayer/Protocol/Clientbound/UpdateLocomotion.cs
+++ b/server/Managed/NativeLayer/Protocol/Clientbound/UpdateLocomotion.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+using Cyberverse.Server.NativeLayer.Protocol.Common;
+
+namespace Cyberverse.Server.NativeLayer.Protocol.Clientbound;
+
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+public struct UpdateLocomotion : IClientBoundPacket
+{
+    public ulong networkedEntityId;
+    public LocomotionState state;
+
+    public EMessageTypeClientbound GetMessageType() => EMessageTypeClientbound.UpdateLocomotion;
+}

--- a/server/Managed/NativeLayer/Protocol/Common/LocomotionState.cs
+++ b/server/Managed/NativeLayer/Protocol/Common/LocomotionState.cs
@@ -1,0 +1,12 @@
+using System.Runtime.InteropServices;
+
+namespace Cyberverse.Server.NativeLayer.Protocol.Common;
+
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+public struct LocomotionState
+{
+    public ushort stanceId;
+    public ushort locomotionId;
+    public ushort overlayId;
+    public ushort phase;
+}

--- a/server/Managed/NativeLayer/Protocol/Serverbound/EMessageTypeServerbound.cs
+++ b/server/Managed/NativeLayer/Protocol/Serverbound/EMessageTypeServerbound.cs
@@ -10,5 +10,7 @@ public enum EMessageTypeServerbound: ushort
     PlayerMountCar = 5, // TODO: Implement
     PlayerUnmountCar = 6,
     PlayerEquipItem = 7,
-    PlayerShoot = 8
+    PlayerShoot = 8,
+    PlayerAppearance = 9,
+    PlayerLocomotion = 10
 }

--- a/server/Managed/NativeLayer/Protocol/Serverbound/PlayerActionTracked.cs
+++ b/server/Managed/NativeLayer/Protocol/Serverbound/PlayerActionTracked.cs
@@ -6,8 +6,10 @@ namespace Cyberverse.Server.NativeLayer.Protocol.Serverbound;
 [StructLayout(LayoutKind.Sequential, Pack = 8)]
 public struct PlayerActionTracked
 {
-    // TODO: bool buttonState? (We could trigger on press or release)
-    // TODO: uint64_t networkTick (relative to the connect in relative server timestamps, because we probably get those batched and relay those batched)
+    // True when the triggering button is pressed
+    public bool buttonState;
+    // Tick counter relative to the connection start
+    public ulong networkTick;
     public EPlayerAction action;
     public Vector3 worldTransform;
 }

--- a/server/Managed/NativeLayer/Protocol/Serverbound/PlayerAppearance.cs
+++ b/server/Managed/NativeLayer/Protocol/Serverbound/PlayerAppearance.cs
@@ -1,0 +1,12 @@
+using System.Runtime.InteropServices;
+using Cyberverse.Server.NativeLayer.Protocol.Common;
+
+namespace Cyberverse.Server.NativeLayer.Protocol.Serverbound;
+
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+public struct PlayerAppearance
+{
+    public uint dataLength;
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 512)]
+    public byte[] data;
+}

--- a/server/Managed/NativeLayer/Protocol/Serverbound/PlayerLocomotion.cs
+++ b/server/Managed/NativeLayer/Protocol/Serverbound/PlayerLocomotion.cs
@@ -1,11 +1,10 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using Cyberverse.Server.NativeLayer.Protocol.Common;
 
 namespace Cyberverse.Server.NativeLayer.Protocol.Serverbound;
 
 [StructLayout(LayoutKind.Sequential, Pack = 8)]
-public struct PlayerJoinWorld
+public struct PlayerLocomotion
 {
-    public Vector3 position;
-    public ulong recordId;
+    public LocomotionState state;
 }

--- a/server/Managed/NativeLayer/Protocol/Serverbound/PlayerPositionUpdate.cs
+++ b/server/Managed/NativeLayer/Protocol/Serverbound/PlayerPositionUpdate.cs
@@ -7,7 +7,8 @@ namespace Cyberverse.Server.NativeLayer.Protocol.Serverbound;
 [StructLayout(LayoutKind.Sequential, Pack = 8)]
 public struct PlayerPositionUpdate
 {
-    // TODO: uint64_t networkTick (relative to the connect in relative server timestamps, because we probably get those batched and relay those batched)
+    // Tick counter relative to the connection start
+    public ulong networkTick;
     public Vector3 worldTransform;
     public float yaw;
 }

--- a/server/Managed/NativeLayer/Protocol/Serverbound/PlayerUnmountCar.cs
+++ b/server/Managed/NativeLayer/Protocol/Serverbound/PlayerUnmountCar.cs
@@ -5,4 +5,5 @@ namespace Cyberverse.Server.NativeLayer.Protocol.Serverbound;
 [StructLayout(LayoutKind.Sequential, Pack = 8)]
 public struct PlayerUnmountCar
 {
+    public ulong networkedEntityId;
 }

--- a/server/Managed/PacketHandling/PlayerPacketHandler.cs
+++ b/server/Managed/PacketHandling/PlayerPacketHandler.cs
@@ -20,6 +20,8 @@ public class PlayerPacketHandler
     private readonly TypedPacketHandler<PlayerUnmountCar> _playerUnmountHandler;
     private readonly TypedPacketHandler<PlayerEquipItem> _playerEquipHandler;
     private readonly TypedPacketHandler<PlayerShoot> _playerShootHandler;
+    private readonly TypedPacketHandler<PlayerAppearance> _playerAppearanceHandler;
+    private readonly TypedPacketHandler<PlayerLocomotion> _playerLocomotionHandler;
     private EntityTracker? _tracker = null;
     private PlayerService? _players = null;
 
@@ -31,17 +33,18 @@ public class PlayerPacketHandler
         _playerUnmountHandler = new TypedPacketHandler<PlayerUnmountCar>(HandleUnmountCar);
         _playerEquipHandler = new TypedPacketHandler<PlayerEquipItem>(HandleEquip);
         _playerShootHandler = new TypedPacketHandler<PlayerShoot>(HandleShoot);
+        _playerAppearanceHandler = new TypedPacketHandler<PlayerAppearance>(HandleAppearance);
+        _playerLocomotionHandler = new TypedPacketHandler<PlayerLocomotion>(HandleLocomotion);
     }
 
     protected void HandleJoinWorld(GameServer server, EMessageTypeServerbound messageType, byte channelId, uint connectionId, PlayerJoinWorld content)
     {
         if (_players!.ConnectedPlayers.TryGetValue(connectionId, out var player))
         {
-            Logger.Trace("Player {0} joined the world at ({1}, {2}, {3})", player.Name, 
-                content.position.x, content.position.y, content.position.z);
+            Logger.Trace("Player {0} joined the world at ({1}, {2}, {3}) with recordId {4}", player.Name,
+                content.position.x, content.position.y, content.position.z, content.recordId);
 
-            var choice = Random.Next(PossiblePlayerNpcChoice.Length);
-            var entity = server.EntityService.CreateEntity(PossiblePlayerNpcChoice[choice]);
+            var entity = server.EntityService.CreateEntity(content.recordId);
             entity.WorldTransform = content.position; // Spawn the entity at the right spot already
             entity.NetworkIdOwner = player.ConnectionId;
                 
@@ -186,6 +189,26 @@ public class PlayerPacketHandler
         Logger.Warn($"Shots fired! {content.itemIdWeapon} at {content.startPoint}");
     }
 
+    private void HandleAppearance(GameServer server, EMessageTypeServerbound messageType, byte channelId,
+        uint connectionId, PlayerAppearance content)
+    {
+        if (!_players!.ConnectedPlayers.TryGetValue(connectionId, out var player))
+            return;
+
+        var entity = server.EntityService.SpawnedEntities.Values
+            .FirstOrDefault(e => e.NetworkIdOwner == player.ConnectionId && !e.IsVehicle);
+        if (entity != null)
+        {
+            entity.AppearanceJson = System.Text.Encoding.UTF8.GetString(content.data, 0, (int)content.dataLength);
+        }
+    }
+
+    private void HandleLocomotion(GameServer server, EMessageTypeServerbound messageType, byte channelId,
+        uint connectionId, PlayerLocomotion content)
+    {
+        // Placeholder: store locomotion state if needed
+    }
+
     public void RegisterOnServer(GameServer server)
     {
         _tracker = server.EntityTracker; // TODO: Service registry or even using DI
@@ -197,5 +220,7 @@ public class PlayerPacketHandler
         server.AddPacketHandler(EMessageTypeServerbound.PlayerUnmountCar, _playerUnmountHandler.HandlePacket);
         server.AddPacketHandler(EMessageTypeServerbound.PlayerEquipItem, _playerEquipHandler.HandlePacket);
         server.AddPacketHandler(EMessageTypeServerbound.PlayerShoot, _playerShootHandler.HandlePacket);
+        server.AddPacketHandler(EMessageTypeServerbound.PlayerAppearance, _playerAppearanceHandler.HandlePacket);
+        server.AddPacketHandler(EMessageTypeServerbound.PlayerLocomotion, _playerLocomotionHandler.HandlePacket);
     }
 }

--- a/server/Managed/PacketHandling/PlayerPacketHandler.cs
+++ b/server/Managed/PacketHandling/PlayerPacketHandler.cs
@@ -79,18 +79,7 @@ public class PlayerPacketHandler
         foreach (var entity in playerEntities)
         {
             //Console.WriteLine($"Move {player.Name} ({player.ConnectionId} / {message.connectionId}) to ({positionUpdate.worldTransform.x}, {positionUpdate.worldTransform.y}, {positionUpdate.worldTransform.z})");
-            
-            // TODO: sometimes the game sends faulty updates to ~0, 3.16, 0.
-            // TODO: This is happening before the savegame has loaded. A better solution is to prevent updating networkEntityIds that are not spawned yet,
-            // because what happens here is that player.NetworkedEntityId is 0 because it has no entity yet, thus moving the old player.
-            // Note: this should already be solved.
-            if (content.worldTransform.z == 0 && content.worldTransform.x == 0.010673523f)
-            {
-                // TODO: we should really remove that.
-                Logger.Trace("Skipping position update");
-                return;
-            }
-                    
+
             entity.WorldTransform = content.worldTransform;
             entity.Yaw = content.yaw;
             _tracker!.UpdateTrackingOf(entity);

--- a/server/Managed/Program.cs
+++ b/server/Managed/Program.cs
@@ -11,7 +11,7 @@ public class Program
     {
         InitLogging();
         LogManager.GetCurrentClassLogger().Info("Starting Cyberverse Server 0.0.1 (c) 2023 MeFisto94");
-        var server = new GameServer(1337);
+        var server = new GameServer(7777);
         AddTypicalPacketHandlers(server);
         
         var quit = false;

--- a/server/Managed/Services/EntityTracker.cs
+++ b/server/Managed/Services/EntityTracker.cs
@@ -43,7 +43,7 @@ public class EntityTracker
             var apply = new ApplyAppearance
             {
                 networkedEntityId = entity.NetworkedEntityId,
-                dataLength = (uint)bytes.Length,
+                dataLength = (uint)count,
                 data = applyData
             };
 

--- a/server/Managed/Types/Entity.cs
+++ b/server/Managed/Types/Entity.cs
@@ -20,6 +20,7 @@ public class Entity
     public float Yaw;
     // TODO: Remove and derive from recordId
     public bool IsVehicle;
+    public string? AppearanceJson;
 
     public Entity(ulong entityId, ulong recordId)
     {

--- a/server/Native/CMakeLists.txt
+++ b/server/Native/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 # Change the project name here!
-project(Cyberverse.Server.Native LANGUAGES CXX)
+project(Cyberverse.Server.Native LANGUAGES C CXX)
 
 # Set this option to ON to be able to use folders / filters in your project when using Visual Studio.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -15,7 +15,10 @@ add_library(zpp_bits INTERFACE)
 target_include_directories(zpp_bits INTERFACE "deps/zpp_bits")
 
 # Include Valve's GameNetworkingSockets
-find_package(GameNetworkingSockets CONFIG REQUIRED)
+find_package(GameNetworkingSockets CONFIG QUIET)
+if(NOT GameNetworkingSockets_FOUND)
+    add_subdirectory(deps/GameNetworkingSockets)
+endif()
 
 # Include our protocol headers (shared with the client)
 add_library(protocol INTERFACE)

--- a/server/Native/src/GameServer.h
+++ b/server/Native/src/GameServer.h
@@ -3,6 +3,8 @@
 
 #include <queue>
 #include <serverbound/AuthPacketsServerBound.h>
+#include <serverbound/WorldPacketsServerBound.h>
+#include <serverbound/AppearancePacketsServerBound.h>
 
 #include <steam/isteamnetworkingsockets.h>
 #include <steam/steamnetworkingtypes.h>
@@ -45,7 +47,7 @@ public:
     void OnConnectionStatusChanged(const SteamNetConnectionStatusChangedCallback_t* pInfo) const;
 public:
     /* DLL API start */
-    bool ListenOn(uint16_t nPort = 1337);
+    bool ListenOn(uint16_t nPort = 7777);
     void RunBlocking();
     void Update(float deltaTime);
 

--- a/server/Native/src/Main.cpp
+++ b/server/Native/src/Main.cpp
@@ -14,7 +14,7 @@ int main()
     }
 
     const auto gameserver = new GameServer();
-    gameserver->ListenOn(1337);
+    gameserver->ListenOn(7777);
     gameserver->RunBlocking();
     GameServer::Destroy();
 }

--- a/shared/protocol/NetworkEnums.h
+++ b/shared/protocol/NetworkEnums.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstdint>
+
+enum class EStance : uint16_t {
+    Stand = 0,
+    Crouch = 1,
+};
+
+enum class ELocomotion : uint16_t {
+    Idle = 0,
+    Walk = 1,
+    Run = 2,
+    Sprint = 3,
+    Swim = 4,
+};
+
+struct LocomotionState {
+    uint16_t stanceId;
+    uint16_t locomotionId;
+    uint16_t overlayId;
+    uint16_t phase;
+};

--- a/shared/protocol/clientbound/AppearancePacketsClientBound.h
+++ b/shared/protocol/clientbound/AppearancePacketsClientBound.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "../MessageFrame.h"
+#include "EMessageTypeClientbound.h"
+#include "../NetworkEnums.h"
+#include <array>
+
+struct ApplyAppearance {
+    uint64_t networkedEntityId;
+    uint32_t dataLength;
+    std::array<uint8_t, 512> data;
+
+    inline static void FillMessageFrame(MessageFrame& frame)
+    {
+        frame.message_type = eApplyAppearance;
+        frame.channel_id = 0;
+    }
+};
+
+struct UpdateLocomotion {
+    uint64_t networkedEntityId;
+    LocomotionState state;
+
+    inline static void FillMessageFrame(MessageFrame& frame)
+    {
+        frame.message_type = eUpdateLocomotion;
+        frame.channel_id = 1;
+    }
+};

--- a/shared/protocol/clientbound/AuthPacketsClientBound.h
+++ b/shared/protocol/clientbound/AuthPacketsClientBound.h
@@ -16,6 +16,6 @@ struct AuthResultClientBound {
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = EINIT_AUTH_RESULT;
-        frame.channel_id = 0; // TODO
+        frame.channel_id = 0;
     }
 };

--- a/shared/protocol/clientbound/EMessageTypeClientbound.h
+++ b/shared/protocol/clientbound/EMessageTypeClientbound.h
@@ -8,4 +8,6 @@ enum EMessageTypeClientbound: uint16_t {
     eTeleportEntity = 2,
     eDestroyEntity = 3,
     eEquipItemEntity = 4,
+    eApplyAppearance = 5,
+    eUpdateLocomotion = 6,
 };

--- a/shared/protocol/clientbound/WorldPacketsClientBound.h
+++ b/shared/protocol/clientbound/WorldPacketsClientBound.h
@@ -15,7 +15,7 @@ struct SpawnEntity {
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = eSpawnEntity;
-        frame.channel_id = 1; // TODO:
+        frame.channel_id = 1;
     }
 };
 
@@ -24,7 +24,7 @@ struct DestroyEntity {
 
     inline static void FillMessageFrame(MessageFrame& frame) {
         frame.message_type = eDestroyEntity;
-        frame.channel_id = 1; // TODO:
+        frame.channel_id = 1;
     }
 };
 
@@ -38,7 +38,7 @@ struct TeleportEntity
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = eTeleportEntity;
-        frame.channel_id = 1; // TODO:
+        frame.channel_id = 1;
     }
 };
 
@@ -52,6 +52,6 @@ struct EquipItemEntity {
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = eEquipItemEntity;
-        frame.channel_id = 0; // TODO
+        frame.channel_id = 0;
     }
 };

--- a/shared/protocol/serverbound/AppearancePacketsServerBound.h
+++ b/shared/protocol/serverbound/AppearancePacketsServerBound.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "../MessageFrame.h"
+#include "EMessageTypeServerbound.h"
+#include "../NetworkEnums.h"
+#include <array>
+
+struct PlayerAppearance {
+    uint32_t dataLength;
+    std::array<uint8_t, 512> data;
+
+    inline static void FillMessageFrame(MessageFrame& frame)
+    {
+        frame.message_type = ePlayerAppearance;
+        frame.channel_id = 0;
+    }
+};
+
+struct PlayerLocomotion {
+    LocomotionState state;
+
+    inline static void FillMessageFrame(MessageFrame& frame)
+    {
+        frame.message_type = ePlayerLocomotion;
+        frame.channel_id = 1;
+    }
+};

--- a/shared/protocol/serverbound/AuthPacketsServerBound.h
+++ b/shared/protocol/serverbound/AuthPacketsServerBound.h
@@ -18,7 +18,7 @@ struct InitAuthServerBound {
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = EINIT_AUTH;
-        frame.channel_id = 0; // TODO
+        frame.channel_id = 0;
     }
 };
 

--- a/shared/protocol/serverbound/EMessageTypeServerbound.h
+++ b/shared/protocol/serverbound/EMessageTypeServerbound.h
@@ -11,5 +11,7 @@ enum EMessageTypeServerbound: uint16_t {
     ePlayerMountCar = 5, // TODO: Implement
     ePlayerUnmountCar = 6,
     ePlayerEquipItem = 7,
-    ePlayerShoot = 8
+    ePlayerShoot = 8,
+    ePlayerAppearance = 9,
+    ePlayerLocomotion = 10
 };

--- a/shared/protocol/serverbound/WorldPacketsServerBound.h
+++ b/shared/protocol/serverbound/WorldPacketsServerBound.h
@@ -5,11 +5,13 @@
 
 struct PlayerJoinWorld {
     Vector3 position;
+    uint64_t recordId;
 
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = EPLAYER_JOIN_WORLD;
-        frame.channel_id = 0; // TODO
+        // Join packets are small and should be reliable
+        frame.channel_id = 0;
     }
 };
 
@@ -21,28 +23,33 @@ enum PlayerAction: uint8_t
 
 struct PlayerActionTracked
 {
-    // TODO: bool buttonState? (We could trigger on press or release)
-    // TODO: uint64_t networkTick (relative to the connect in relative server timestamps, because we probably get those batched and relay those batched)
+    // True when the button causing the action was pressed, false on release
+    bool buttonState;
+    // Relative tick count since connection establishment
+    uint64_t networkTick;
     PlayerAction action;
     Vector3 worldTransform;
 
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = ePlayerActionTracked;
-        frame.channel_id = 1; // TODO
+        // Input actions are sent unreliably
+        frame.channel_id = 1;
     }
 };
 
 struct PlayerPositionUpdate
 {
-    // TODO: uint64_t networkTick (relative to the connect in relative server timestamps, because we probably get those batched and relay those batched)
+    // Relative tick count since connection establishment
+    uint64_t networkTick;
     Vector3 worldTransform;
     float yaw;
 
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = ePlayerPositionUpdate;
-        frame.channel_id = 1; // TODO
+        // Position updates are sent on the unreliable channel
+        frame.channel_id = 1;
     }
 };
 
@@ -55,17 +62,17 @@ struct PlayerSpawnCar {
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = ePlayerSpawnCar;
-        frame.channel_id = 0; // TODO
+        frame.channel_id = 0;
     }
 };
 
 struct PlayerUnmountCar {
-    // TODO: NetworkedEntityId
+    uint64_t networkedEntityId;
 
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = ePlayerUnmountCar;
-        frame.channel_id = 0; // TODO
+        frame.channel_id = 0;
     }
 };
 
@@ -78,7 +85,7 @@ struct PlayerEquipItem {
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = ePlayerEquipItem;
-        frame.channel_id = 0; // TODO
+        frame.channel_id = 0;
     }
 };
 
@@ -91,6 +98,6 @@ struct PlayerShoot {
     inline static void FillMessageFrame(MessageFrame& frame)
     {
         frame.message_type = ePlayerShoot;
-        frame.channel_id = 0; // TODO
+        frame.channel_id = 0;
     }
 };


### PR DESCRIPTION
## Summary
- include RedLib headers using angle brackets for consistency
- enable bundled dependencies to satisfy CMake builds
- add build.ps1 script for Windows users
- compile RED4ext SDK in header-only mode
- pad appearance packet byte arrays on the server

## Testing
- `dotnet build server/Managed -c Release` *(fails: command not found)*
- `cmake -B server/Native/build -S server/Native` *(fails: GameNetworkingSockets missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ff61d1b6c832996ae5712b51f6009